### PR TITLE
Fix console error on main page originating from typo

### DIFF
--- a/docs/developers/tutorials/circles-by-hand-with-sbt-ethereum.md
+++ b/docs/developers/tutorials/circles-by-hand-with-sbt-ethereum.md
@@ -225,7 +225,7 @@ Scrape for the ABI? [y/n] y
 Ready to import the following ABI:
 ```
 <details><summary><i>Show ABI</i></summary>
-<p>
+<div>
 
 ```
 [ {
@@ -654,7 +654,7 @@ Ready to import the following ABI:
 } ]
 ```
 
-</p>
+</div>
 </details>
 
 ```
@@ -1050,7 +1050,7 @@ Contract ABI or Source: https://github.com/CirclesUBI/circles-contracts/blob/mas
 Ready to import the following ABI:
 ```
 <details><summary><i>Show ABI</i></summary>
-<p>
+<div>
 
 ```
 [ {
@@ -1444,7 +1444,7 @@ Ready to import the following ABI:
 } ]
 ```
 
-</p>
+</div>
 </details>
 
 ```
@@ -1681,7 +1681,7 @@ We’ve also seen that we can trust other identities, fully or partially, to def
 ## Appendix: Circles hub source code
 
 <details><summary>Click here to show the full source code of the Circles hub. It includes the source code of the generated ERC-20 token contracts.</summary>
-<p>
+<div>
 
 ```javascript
 // File: @openzeppelin/contracts/math/SafeMath.sol
@@ -2836,5 +2836,5 @@ contract Hub {
     }
 }
 ```
-</p>
+</div>
 </details>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,9 +24,9 @@ const DocumentationLink = ({ imageUrl, title, children }) => {
 };
 
 DocumentationLink.propTypes = {
-  children: PropTypes.node.required,
-  imageUrl: PropTypes.string.required,
-  title: PropTypes.string.required,
+  children: PropTypes.node.isRequired,
+  imageUrl: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 const Home = () => {


### PR DESCRIPTION
On the main branch there is a console error which should be resolved by this PR.

Based on [prop-type documentation](https://www.npmjs.com/package/prop-types) it should be `PropTypes.node.isRequired,` instead of `PropTypes.node.required,`. 